### PR TITLE
Add activate to start of script

### DIFF
--- a/Templates.applescript
+++ b/Templates.applescript
@@ -63,6 +63,7 @@ property specialTemplateFolder : null
 
 -- If not the first time run the script then set the status of template folder to Active. 
 try
+	tell application "OmniFocus" to activate
 	if firstRun = false then
 		tell application "OmniFocus"
 			tell default document

--- a/Templates.applescript
+++ b/Templates.applescript
@@ -63,7 +63,14 @@ property specialTemplateFolder : null
 
 -- If not the first time run the script then set the status of template folder to Active. 
 try
-	tell application "OmniFocus" to activate
+	tell application "OmniFocus"
+		tell default document
+			if visible of front document window is false then
+				make new document window at end of document windows
+			end if
+		end tell
+		activate
+	end tell	
 	if firstRun = false then
 		tell application "OmniFocus"
 			tell default document


### PR DESCRIPTION
In order to properly show OmniFocus, the script should activate OmniFocus so that you don't just get a bouncing dock icon if you run the script when OmniFocus isn't the frontmost app.
